### PR TITLE
Update mappings to replace the `Vim*` actions with corresponding keys

### DIFF
--- a/spacemacs/compile-comments.vim
+++ b/spacemacs/compile-comments.vim
@@ -8,19 +8,19 @@ vnoremap <leader>cc    :action CompileDirty<CR>
 
 " Comment lines
 nnoremap <leader>cl    :action CommentByLineComment<CR>
-vnoremap <leader>cl    :action CommentByLineComment<CR><Esc>
+vnoremap <leader>cl    :action CommentByLineComment<CR>
 
 " Make module
 nnoremap <leader>cm    :action MakeModule<CR>
 vnoremap <leader>cm    :action MakeModule<CR>
 
 " Comment paragraph
-nnoremap <leader>cp    vip:action CommentByLineComment<CR><Esc>
-vnoremap <leader>cp    <Esc>vip:action CommentByLineComment<CR><Esc>
+nnoremap <leader>cp    vip:action CommentByLineComment<CR>
+vnoremap <leader>cp    <Esc>vip:action CommentByLineComment<CR>
 
 " Comment from begin of buffer up to current line
-nnoremap <leader>ct    Vgg:action CommentByLineComment<CR><Esc>
-vnoremap <leader>ct    <Esc>Vgg:action CommentByLineComment<CR><Esc>
+nnoremap <leader>ct    Vgg:action CommentByLineComment<CR>
+vnoremap <leader>ct    <Esc>Vgg:action CommentByLineComment<CR>
 
 " Copy and comment current line
 nnoremap <leader>cy    yyP:action CommentByLineComment<CR>

--- a/spacemacs/compile-comments.vim
+++ b/spacemacs/compile-comments.vim
@@ -7,20 +7,20 @@ nnoremap <leader>cc    :action CompileDirty<CR>
 vnoremap <leader>cc    :action CompileDirty<CR>
 
 " Comment lines
-nnoremap <leader>cl    :action CommentByLineComment<CR>:action VimVisualExitMode<CR>
-vnoremap <leader>cl    :action CommentByLineComment<CR>:action VimVisualExitMode<CR>
+nnoremap <leader>cl    :action CommentByLineComment<CR>
+vnoremap <leader>cl    :action CommentByLineComment<CR><Esc>
 
 " Make module
 nnoremap <leader>cm    :action MakeModule<CR>
 vnoremap <leader>cm    :action MakeModule<CR>
 
 " Comment paragraph
-nnoremap <leader>cp    vip:action CommentByLineComment<CR>:action VimVisualExitMode<CR>
-vnoremap <leader>cp    <Esc>vip:action CommentByLineComment<CR>:action VimVisualExitMode<CR>
+nnoremap <leader>cp    vip:action CommentByLineComment<CR><Esc>
+vnoremap <leader>cp    <Esc>vip:action CommentByLineComment<CR><Esc>
 
 " Comment from begin of buffer up to current line
-nnoremap <leader>ct    Vgg:action CommentByLineComment<CR>:action VimVisualExitMode<CR>
-vnoremap <leader>ct    <Esc>Vgg:action CommentByLineComment<CR>:action VimVisualExitMode<CR>
+nnoremap <leader>ct    Vgg:action CommentByLineComment<CR><Esc>
+vnoremap <leader>ct    <Esc>Vgg:action CommentByLineComment<CR><Esc>
 
 " Copy and comment current line
 nnoremap <leader>cy    yyP:action CommentByLineComment<CR>

--- a/spacemacs/leader.vim
+++ b/spacemacs/leader.vim
@@ -27,7 +27,7 @@ vnoremap <leader>*    :action ShowUsages<CR>
 
 " Comment lines
 nnoremap <leader>;;    :action CommentByLineComment<CR>
-vnoremap <leader>;     :action CommentByLineComment<CR><Esc>
+vnoremap <leader>;     :action CommentByLineComment<CR>
 
 " Show key bindings
 nnoremap <leader>?    :map<CR>

--- a/spacemacs/leader.vim
+++ b/spacemacs/leader.vim
@@ -27,7 +27,7 @@ vnoremap <leader>*    :action ShowUsages<CR>
 
 " Comment lines
 nnoremap <leader>;;    :action CommentByLineComment<CR>
-vnoremap <leader>;     :action CommentByLineComment<CR>:action VimVisualExitMode<CR>
+vnoremap <leader>;     :action CommentByLineComment<CR><Esc>
 
 " Show key bindings
 nnoremap <leader>?    :map<CR>

--- a/spacemacs/windows.vim
+++ b/spacemacs/windows.vim
@@ -49,12 +49,12 @@ nnoremap <leader>wpm    :action ActivateEventLogToolWindow<CR>
 vnoremap <leader>wpm    :action ActivateEventLogToolWindow<CR>
 
 " Split window below and focus
-nnoremap <leader>wS    :action SplitHorizontally<CR>:action VimWindowDown<CR>
-vnoremap <leader>wS    <Esc>:action SplitHorizontally<CR>:action VimWindowDown<CR>
+nnoremap <leader>wS    <C-w>s<C-w>j
+vnoremap <leader>wS    <Esc><C-w>s<C-w>j
 
 " Split window right and focus
-nnoremap <leader>wV    :action SplitVertically<CR>:action VimWindowRight<CR>
-vnoremap <leader>wV    <Esc>:action SplitVertically<CR>:action VimWindowRight<CR>
+nnoremap <leader>wV    <C-w>v<C-w>l
+vnoremap <leader>wV    <Esc><C-w>v<C-w>l
 
 " Focus next window
 nnoremap <leader>ww    :action NextSplitter<CR>


### PR DESCRIPTION
Hi! Since 0.54 version of IdeaVim all the `Vim*` actions don't work (see https://youtrack.jetbrains.com/issue/VIM-1871#focus=streamItem-27-3864326.0-0).
Here is an updated version of your config. 
1) Unfortunately, `:action CommentByLineComment<CR><Esc>` doesn't work as expected. This is definitely a [bug](https://youtrack.jetbrains.com/issue/VIM-1877).
2) I don't fully understand what do you mean about `<C-S-6>` mappings, but you should map your keys to `<C-S-6>` (and not to `VimFilePrevious`).