### PR TITLE
Explain how to disable A-x for opening action due to conflict with multiple cursors

### DIFF
--- a/extra/settings.vim
+++ b/extra/settings.vim
@@ -11,3 +11,8 @@ set textobj-entire
 
 " Replace with register content shortcut: https://github.com/vim-scripts/ReplaceWithRegister
 set ReplaceWithRegister
+
+" Intellimacs by default uses <A-X> to execute an action, if you want to use
+" this key binding with multiple-cursors plugin add the following line
+" (without ") at the end of your ~/.ideavimrc file
+" vunmap <A-X>


### PR DESCRIPTION
When multi cursors is enabled. 
`<A-X>` is used by the plugin during visual mode. It conflicts with spacemacs mappin definition.