### PR TITLE
adding dash / quick docs and type defs

### DIFF
--- a/docs/PLUGINS.org
+++ b/docs/PLUGINS.org
@@ -10,3 +10,6 @@ A list of useful plugins that help to replicate the Spacemacs experience.
 
 * String inflection
 [[https://plugins.jetbrains.com/plugin/7160-camelcase/][CamelCase]] allows you to switch easily between CamelCase, camelCase, snake_case and SNAKE_CASE.
+
+* Documentation Search (MacOs)
+[[https://kapeli.com/dash][Dash]] gives your Mac instant offline access to 200+ API documentation sets.

--- a/spacemacs.vim
+++ b/spacemacs.vim
@@ -8,6 +8,7 @@ source ~/.intellimacs/spacemacs/applications.vim
 source ~/.intellimacs/spacemacs/buffers.vim
 source ~/.intellimacs/spacemacs/colors.vim
 source ~/.intellimacs/spacemacs/compile-comments.vim
+source ~/.intellimacs/spacemacs/docs.vim
 source ~/.intellimacs/spacemacs/errors.vim
 source ~/.intellimacs/spacemacs/files.vim
 source ~/.intellimacs/spacemacs/frame.vim

--- a/spacemacs/docs.vim
+++ b/spacemacs/docs.vim
@@ -1,0 +1,13 @@
+" Quick Documentation / JavaDoc
+nnoremap <leader>dj          :action QuickJavaDoc<CR>
+vnoremap <leader>dj          :action QuickJavaDoc<CR>
+
+" Type Definition
+nnoremap <leader>df          :action QuickTypeDefinition<CR>
+vnoremap <leader>df          :action QuickTypeDefinition<CR>
+
+" Doc search (Dash required - macOS only)
+nnoremap <leader>dd          :action SmartSearchAction<CR>
+vnoremap <leader>dd          :action SmartSearchAction<CR>
+nnoremap <leader>dD          :action SearchAction<CR>
+vnoremap <leader>dD          :action SearchAction<CR>


### PR DESCRIPTION
Might be useful to those who use Dash - kept the same keybindings from the spacemacs dash layer.  QuickDef and TypeDef are not standard, though I find the bindings useful. 