### PR TITLE
Add which-key names for errors.

### DIFF
--- a/docs/KEYBINDINGS.org
+++ b/docs/KEYBINDINGS.org
@@ -67,14 +67,17 @@ master branch.
 
 ** errors
 
-| Key binding | Description       |
-|-------------+-------------------|
-| ~SPC e l~   | List errors       |
-| ~SPC e N~   | Previous error    |
-| ~SPC e n~   | Next error        |
-| ~SPC e p~   | Previous error    |
-| ~SPC e s~   | Select inspection |
-| ~SPC e x~   | Explain error     |
+| Key binding | Description            |
+|-------------+------------------------|
+| ~SPC e L~   | Inspect code           |
+| ~SPC e l~   | List errors            |
+| ~SPC e N~   | Previous error         |
+| ~SPC e n~   | Next error             |
+| ~SPC e p~   | Previous error         |
+| ~SPC e R~   | Run inspection by name |
+| ~SPC e r~   | Resolve error          |
+| ~SPC e s~   | Inspection settings    |
+| ~SPC e x~   | Explain error          |
 
 ** frame
 

--- a/extra/errors.vim
+++ b/extra/errors.vim
@@ -3,11 +3,6 @@ let g:WhichKeyDesc_Errors_InspectCode = "<leader>eL inspect-code"
 nnoremap <leader>eL    :action InspectCode<CR>
 vnoremap <leader>eL    :action InspectCode<CR>
 
-" List errors
-let g:WhichKeyDesc_Errors_ListErrors = "<leader>el list-errors"
-nnoremap <leader>el    :action CodeInspection.OnEditor<CR>
-vnoremap <leader>el    :action CodeInspection.OnEditor<CR>
-
 " Run inspection by name
 let g:WhichKeyDesc_Errors_RunInspectionByName = "<leader>eR run-inspection-by-name"
 nnoremap <leader>eR    :action RunInspection<CR>
@@ -17,13 +12,3 @@ vnoremap <leader>eR    <Esc>:action RunInspection<CR>
 let g:WhichKeyDesc_Errors_ResolveError = "<leader>er resolve-error"
 nnoremap <leader>er    :action ShowIntentionActions<CR>
 vnoremap <leader>er    :action ShowIntentionActions<CR>
-
-" Edit inspection settings
-let g:WhichKeyDesc_Errors_OpenInspectionSettings = "<leader>es inspection-settings"
-nnoremap <leader>es    :action EditInspectionSettings<CR>
-vnoremap <leader>es    :action EditInspectionSettings<CR>
-
-" Explain error at cursor
-let g:WhichKeyDesc_Errors_ExplainError = "<leader>ex explain-error"
-nnoremap <leader>ex    :action ShowErrorDescription<CR>
-vnoremap <leader>ex    :action ShowErrorDescription<CR>

--- a/extra/errors.vim
+++ b/extra/errors.vim
@@ -1,11 +1,29 @@
 " Inspect code
+let g:WhichKeyDesc_Errors_InspectCode = "<leader>eL inspect-code"
 nnoremap <leader>eL    :action InspectCode<CR>
 vnoremap <leader>eL    :action InspectCode<CR>
 
+" List errors
+let g:WhichKeyDesc_Errors_ListErrors = "<leader>el list-errors"
+nnoremap <leader>el    :action CodeInspection.OnEditor<CR>
+vnoremap <leader>el    :action CodeInspection.OnEditor<CR>
+
+" Run inspection by name
+let g:WhichKeyDesc_Errors_RunInspectionByName = "<leader>eR run-inspection-by-name"
+nnoremap <leader>eR    :action RunInspection<CR>
+vnoremap <leader>eR    <Esc>:action RunInspection<CR>
+
 " Resolve error
+let g:WhichKeyDesc_Errors_ResolveError = "<leader>er resolve-error"
 nnoremap <leader>er    :action ShowIntentionActions<CR>
 vnoremap <leader>er    :action ShowIntentionActions<CR>
 
 " Edit inspection settings
+let g:WhichKeyDesc_Errors_OpenInspectionSettings = "<leader>es inspection-settings"
 nnoremap <leader>es    :action EditInspectionSettings<CR>
 vnoremap <leader>es    :action EditInspectionSettings<CR>
+
+" Explain error at cursor
+let g:WhichKeyDesc_Errors_ExplainError = "<leader>ex explain-error"
+nnoremap <leader>ex    :action ShowErrorDescription<CR>
+vnoremap <leader>ex    :action ShowErrorDescription<CR>

--- a/spacemacs/errors.vim
+++ b/spacemacs/errors.vim
@@ -1,3 +1,8 @@
+" List errors
+let g:WhichKeyDesc_Errors_ListErrors = "<leader>el list-errors"
+nnoremap <leader>el    :action CodeInspection.OnEditor<CR>
+vnoremap <leader>el    :action CodeInspection.OnEditor<CR>
+
 " Go to previous error
 let g:WhichKeyDesc_Errors_PreviousError = "<leader>eN previous-error"
 nnoremap <leader>eN    :action GotoPreviousError<CR>
@@ -12,3 +17,13 @@ vnoremap <leader>en    <Esc>:action GotoNextError<CR>
 let g:WhichKeyDesc_Errors_PreviousErrorAlt = "<leader>ep previous-error"
 nnoremap <leader>ep    :action GotoPreviousError<CR>
 vnoremap <leader>ep    <Esc>:action GotoPreviousError<CR>
+
+" Edit inspection settings
+let g:WhichKeyDesc_Errors_OpenInspectionSettings = "<leader>es inspection-settings"
+nnoremap <leader>es    :action PopupHector<CR>
+vnoremap <leader>es    :action PopupHector<CR>
+
+" Explain error at cursor
+let g:WhichKeyDesc_Errors_ExplainError = "<leader>ex explain-error"
+nnoremap <leader>ex    :action ShowErrorDescription<CR>
+vnoremap <leader>ex    :action ShowErrorDescription<CR>

--- a/spacemacs/errors.vim
+++ b/spacemacs/errors.vim
@@ -1,23 +1,14 @@
-" List errors
-nnoremap <leader>el    :action CodeInspection.OnEditor<CR>
-vnoremap <leader>el    :action CodeInspection.OnEditor<CR>
-
 " Go to previous error
+let g:WhichKeyDesc_Errors_PreviousError = "<leader>eN previous-error"
 nnoremap <leader>eN    :action GotoPreviousError<CR>
 vnoremap <leader>eN    <Esc>:action GotoPreviousError<CR>
 
 " Go to next error
+let g:WhichKeyDesc_Errors_NextError = "<leader>en next-error"
 nnoremap <leader>en    :action GotoNextError<CR>
 vnoremap <leader>en    <Esc>:action GotoNextError<CR>
 
 " Go to previous error
+let g:WhichKeyDesc_Errors_PreviousErrorAlt = "<leader>ep previous-error"
 nnoremap <leader>ep    :action GotoPreviousError<CR>
 vnoremap <leader>ep    <Esc>:action GotoPreviousError<CR>
-
-" Select inspection by name
-nnoremap <leader>es    :action RunInspection<CR>
-vnoremap <leader>es    <Esc>:action RunInspection<CR>
-
-" Explain error at point
-nnoremap <leader>ex    :action ShowErrorDescription<CR>
-vnoremap <leader>ex    :action ShowErrorDescription<CR>


### PR DESCRIPTION
Moved a few shortcuts that weren't part of spacemacs from
from `spacemacs/errors.vim` to `extra/errors.vim`

Two shorcuts both had a `<leader>es` mapping.  Remapped one of them.

Relates to #17

## Description
Please explain the changes you made here.

## Checklist
- [x] I have read
[CONTRIBUTING](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CONTRIBUTING.org)
guidelines.

#### [CHANGELOG](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CHANGELOG.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [x] No need to update

#### [KEYBINDINGS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/KEYBINDINGS.org):
- [x] Updated
- [ ] I will update it after this PR has been discussed
- [ ] No need to update

#### [PLUGINS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/PLUGINS.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [x] No need to update
