### PR TITLE
docs: fix typo

### DIFF
--- a/docs/KEYBINDINGS.org
+++ b/docs/KEYBINDINGS.org
@@ -3,7 +3,7 @@
 This file contains all available key bindings.
 They are divided into the three modules: spacemacs, major and extra.
 
-The spacemacs module key bindings are alligned with the spacemacs develop branch, because the
+The spacemacs module key bindings are aligned with the spacemacs develop branch, because the
 0.300 release is very near, but after that we plan to stay aligned with the
 master branch.
 


### PR DESCRIPTION
Fix a typo on `docs/KEYBINDINGS.org`.

## Description
Please explain the changes you made here.

## Checklist
- [X] I have read [CONTRIBUTING](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CONTRIBUTING.org) guidelines.

#### [CHANGELOG](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CHANGELOG.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [X] No need to update

#### [KEYBINDINGS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/KEYBINDINGS.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [X] No need to update

#### [PLUGINS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/PLUGINS.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [X] No need to update
