### PR TITLE
Docs(KEYBINDINGS) fix typo

### DIFF
--- a/docs/KEYBINDINGS.org
+++ b/docs/KEYBINDINGS.org
@@ -97,7 +97,7 @@ master branch.
 | ~SPC f f~   | Find files            |
 | ~SPC f g~   | Search in project     |
 | ~SPC f R~   | Rename file           |
-| ~SPC f r~   | Recent fles           |
+| ~SPC f r~   | Recent files          |
 | ~SPC f S~   | Save all files        |
 | ~SPC f s~   | Save file             |
 | ~SPC f t~   | Project window        |


### PR DESCRIPTION
## Description
Fix another typo in `docs/KEYBINDINGS.org`

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CONTRIBUTING.org) guidelines.

#### [CHANGELOG](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CHANGELOG.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [x] No need to update

#### [KEYBINDINGS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/KEYBINDINGS.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [x] No need to update

#### [PLUGINS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/PLUGINS.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [x] No need to update
