### PR TITLE
`SPC b t` pins tab

### DIFF
--- a/docs/CHANGELOG.org
+++ b/docs/CHANGELOG.org
@@ -7,6 +7,9 @@ and this project adheres to [[https://semver.org/spec/v2.0.0.html][Semantic Vers
 
 * [[https://github.com/marcoieni/intellimacs/compare/v1.1.0...HEAD][Unreleased]]
 
+** Added
+  - =SPC b t=: Pin tab
+
 ** Changed
    - =SPC q r=: Just restarts the IDE without invalidating the cache
 

--- a/docs/KEYBINDINGS.org
+++ b/docs/KEYBINDINGS.org
@@ -398,6 +398,7 @@ master branch.
 | ~SPC b $~   | Go to last tab  |
 | ~SPC b j~   | Previous tab    |
 | ~SPC b k~   | Next tab        |
+| ~SPC b t~   | Pin tab         |
 
 ** compile/comments
 

--- a/extra/buffers.vim
+++ b/extra/buffers.vim
@@ -17,3 +17,8 @@ vnoremap <leader>bk    <Esc>:action NextTab<CR>
 let g:WhichKeyDesc_Buffers_PreviousTab = "<leader>bj    previous-tab"
 nnoremap <leader>bj    :action PreviousTab<CR>
 vnoremap <leader>bj    <Esc>:action PreviousTab<CR>
+
+" Pin Tab
+let g:WhichKeyDesc_Buffers_Pin = "<leader>bt    pin-buffer"
+nnoremap <leader>bt    :action PinActiveTab<CR>
+vnoremap <leader>bt    <Esc>:action PinActiveTab<CR>


### PR DESCRIPTION
## Description
Add a binding for pinning the current active tab (buffer).

The reasoning for why it's `SPC b t` specifically I am not sure. I was considering `SPC b !` and `SPC w P` as well, but I realised that the VSpaceCode has a binding for this, so I figured why not be consistent with them if we're able?

https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md#:~:text=Add%20%3Cspc%3E%20b%20t%20to%20pin%20editor

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CONTRIBUTING.org) guidelines.

#### [CHANGELOG](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CHANGELOG.org):
- [x] Updated
- [ ] I will update it after this PR has been discussed
- [ ] No need to update

#### [KEYBINDINGS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/KEYBINDINGS.org):
- [x] Updated
- [ ] I will update it after this PR has been discussed
- [ ] No need to update

#### [PLUGINS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/PLUGINS.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [x] No need to update
