### PR TITLE
Change `SPC w m` to toggle maximize window

### DIFF
--- a/docs/CHANGELOG.org
+++ b/docs/CHANGELOG.org
@@ -12,6 +12,7 @@ and this project adheres to [[https://semver.org/spec/v2.0.0.html][Semantic Vers
 
 ** Changed
    - =SPC q r=: Just restarts the IDE without invalidating the cache
+   - =SPC w m=: Toggle maximize of active window. Old behaviour still exists at =SPC T m=
 
 * [[https://github.com/marcoieni/intellimacs/compare/v1.0.0...v1.1.0][1.1.0]] - 2020-03-30
 

--- a/docs/KEYBINDINGS.org
+++ b/docs/KEYBINDINGS.org
@@ -262,6 +262,7 @@ master branch.
 | ~SPC w S~     | Split window below and focus |
 | ~SPC w V~     | Split window right and focus |
 | ~SPC w w~     | Focus next window            |
+| ~SPC w m~     | Toggle maximize window       |
 
 ** zoom
 
@@ -494,7 +495,6 @@ master branch.
 | ~SPC w J~   | Focus window very bottom        |
 | ~SPC w K~   | Focus window very top           |
 | ~SPC w L~   | Focus window far right          |
-| ~SPC w m~   | Show only code windows          |
 | ~SPC w O~   | Move tab to the opposite window |
 
 ** zoom

--- a/extra/windows.vim
+++ b/extra/windows.vim
@@ -18,11 +18,6 @@ let g:WhichKeyDesc_Windows_FocusWindowFarRight = "<leader>wL focus-window-far-ri
 nnoremap <leader>wL    10<C-w>l
 vnoremap <leader>wL    <Esc>10<C-w>l
 
-" Close all other windows
-let g:WhichKeyDesc_Windows_CloseAllOtherWindows = "<leader>wm close-all-other-windows"
-nnoremap <leader>wm    :action HideAllWindows<CR>
-vnoremap <leader>wm    :action HideAllWindows<CR>
-
 " Move tab to the opposite window
 let g:WhichKeyDesc_Windows_MoveTabToOppositeWindow = "<leader>wO move-tab-to-opposite-window"
 nnoremap <leader>wO    :action MoveEditorToOppositeTabGroup<CR>

--- a/spacemacs/windows.vim
+++ b/spacemacs/windows.vim
@@ -79,3 +79,8 @@ vnoremap <leader>wV    <Esc><C-w>v<C-w>l
 let g:WhichKeyDesc_Windows_OtherWindow = "<leader>ww other-window"
 nnoremap <leader>ww    :action NextSplitter<CR>
 vnoremap <leader>ww    <Esc>:action NextSplitter<CR>
+
+" Toggle maximized window
+let g:WhichKeyDesc_Windows_ToggleMaximizeWindow = "<leader>wm toggle-maximize-window"
+nnoremap <leader>wm    :action MaximizeEditorInSplit<CR>
+vnoremap <leader>wm    <Esc>:action MaximizeEditorInSplit<CR>


### PR DESCRIPTION
## Description
This PR removes the current behaviour (HideAllWindows) of `SPC w m` which is defined under "extras". The removed behaviour still exists at `SPC T m` (defined under "extras").

Instead, I defined `SPC w m` under "spacemacs" to toggle the maximization of the current window. Pressing it onces will maximize the size of the split, and pressing it again will unmaximize the split.

As far as I understand, this closely matches actual Spacemacs behaviour. Source:
- https://develop.spacemacs.org/doc/DOCUMENTATION.html#:~:text=SPC%20w%20m,to%20delete%2Dother%2Dwindows)
- https://www.reddit.com/r/spacemacs/comments/a1djxx/whats_your_window_layout/eapqhyw/
-  https://gist.github.com/heroheman/befa66b5b4dc5d94682206ece4a91a18#:~:text=SPC%20w%20m,toggle%20maximize%20window

This also seems to mostly match the behaviour of VSpaceCode:
- https://github.com/VSpaceCode/VSpaceCode/blob/3a5f908feb65fd88c3e2c5ec7f3eb5ea7c3bf7c0/CHANGELOG.md?plain=1#L52

VSpaceCode seems to alter slightly from this PR. My suggested `SPC w m` maximizes the width of the current panel, which in effect makes all the other splits smaller. VSpaceCode used to work like this, but instead eventually changed `SPC w m` to *truly* maximize the current split, making other splits invisible. This behaviour I'm not sure that I can replicate in IntelliJ.

I suggest that if a new user who is used to Spacemacs and only imports "spacemacs" and not "extras", tries `SPC w m`, my suggested behaviour is close enough to what they would expect to happen.

You might argue that I should leave the existing binding and just make my new binding under `SPC w M` instead. I think a new user who tries `SPC w m` is still bothered as its behaviour doesn’t seem to match what Spacemacs does. Instead, it just toggles hiding all tool windows. If you don't have those open, it does nothing to "maximize" the current split.

**To sum up:**
- for users who only use the "spacemacs" import, this adds a new command `SPC w m` that previously seems to have no similar action under this namespace
- for users who also use the "extras" import, this removes `SPC w m` but they can access the same behaviour under `SPC T m` instead

## Checklist
- [x] I have read [CONTRIBUTING](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CONTRIBUTING.org) guidelines.

#### [CHANGELOG](https://github.com/MarcoIeni/intellimacs/blob/master/docs/CHANGELOG.org):
- [x] Updated
- [ ] I will update it after this PR has been discussed
- [ ] No need to update

#### [KEYBINDINGS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/KEYBINDINGS.org):
- [x] Updated
- [ ] I will update it after this PR has been discussed
- [ ] No need to update

#### [PLUGINS](https://github.com/MarcoIeni/intellimacs/blob/master/docs/PLUGINS.org):
- [ ] Updated
- [ ] I will update it after this PR has been discussed
- [x] No need to update
